### PR TITLE
Fix wrong case in require

### DIFF
--- a/src/api/Alliances.js
+++ b/src/api/Alliances.js
@@ -1,7 +1,7 @@
 const ExtendableFunction = require('../internal/ExtendableFunction');
 const Search = require('./Search');
 
-const _names = require('../internal/Names');
+const _names = require('../internal/names');
 
 /**
  * An api adapter that provides functions for accessing various details for an


### PR DESCRIPTION
To test in a case-sensitive file system, you can create a disk image with a case sensitive image, mount it, and test there.